### PR TITLE
Fix code scanning alert no. 2: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/workspace/ui/UiSimpleList.java
+++ b/src/main/java/workspace/ui/UiSimpleList.java
@@ -24,7 +24,7 @@ public class UiSimpleList extends UiComponent {
 
     @Override
     public void onDraw(Graphics g) {
-        int y = 300;
+        float y = 300;
         int padding = 5;
         int gap = 5;
 


### PR DESCRIPTION
Fixes [https://github.com/ArtifactForms/MeshLibCore/security/code-scanning/2](https://github.com/ArtifactForms/MeshLibCore/security/code-scanning/2)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `y` from `int` to `float` to match the type of `g.getTextSize()`. This will prevent any implicit narrowing conversion and preserve the precision of the calculations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
