### PR TITLE
Add ClientWorldOrigin and automatic floating-origin shift in ChunkManager

### DIFF
--- a/voxels-client/src/main/java/client/app/GameClient.java
+++ b/voxels-client/src/main/java/client/app/GameClient.java
@@ -11,6 +11,7 @@ import client.ui.ClientView;
 import client.ui.View;
 import client.world.ChunkManager;
 import client.world.ClientWorld;
+import client.world.ClientWorldOrigin;
 import common.network.NetworkPackets;
 import engine.application.BasicApplication;
 import engine.scene.camera.Camera;
@@ -75,6 +76,10 @@ public class GameClient {
 
   public ClientWorld getWorld() {
     return world;
+  }
+
+  public ClientWorldOrigin getWorldOrigin() {
+    return world.getOrigin();
   }
 
   public ClientPlayer getPlayer() {

--- a/voxels-client/src/main/java/client/world/ChunkManager.java
+++ b/voxels-client/src/main/java/client/world/ChunkManager.java
@@ -26,6 +26,8 @@ import math.Vector3f;
  */
 public class ChunkManager extends AbstractComponent implements RenderableComponent {
 
+  private static final int DEFAULT_ORIGIN_SHIFT_THRESHOLD_CHUNKS = 4;
+
   private int renderDistance;
   private int bufferDistance;
 
@@ -52,6 +54,8 @@ public class ChunkManager extends AbstractComponent implements RenderableCompone
   private ChunkRenderer chunkRenderer;
 
   private ClientWorld world;
+  private final ClientWorldOrigin origin;
+  private int originShiftThresholdChunks = DEFAULT_ORIGIN_SHIFT_THRESHOLD_CHUNKS;
 
   // Füge eine Map für den Lösch-Timer hinzu
   private final Map<Long, Long> deletionQueue = new ConcurrentHashMap<>();
@@ -59,6 +63,7 @@ public class ChunkManager extends AbstractComponent implements RenderableCompone
 
   public ChunkManager(GameClient client) {
     this.world = client.getWorld();
+    this.origin = world.getOrigin();
     this.chunkRenderer = new BasicChunkRenderer(client);
     setRenderDistance(GameSettings.renderDistance);
   }
@@ -71,6 +76,11 @@ public class ChunkManager extends AbstractComponent implements RenderableCompone
 
     playerChunkX = WorldMath.worldToChunkX(playerPosition);
     playerChunkZ = WorldMath.worldToChunkZ(playerPosition);
+
+    if (origin.isOutsideShiftThreshold(
+        playerChunkX, playerChunkZ, originShiftThresholdChunks)) {
+      origin.setOriginChunk(playerChunkX, playerChunkZ);
+    }
 
     if (playerChunkX != lastPlayerChunkX || playerChunkZ != lastPlayerChunkZ) {
 
@@ -397,6 +407,21 @@ public class ChunkManager extends AbstractComponent implements RenderableCompone
 
   public void updatePlayerPosition(float x, float y, float z) {
     playerPosition.set(x, y, z);
+  }
+
+  public ClientWorldOrigin getOrigin() {
+    return origin;
+  }
+
+  public int getOriginShiftThresholdChunks() {
+    return originShiftThresholdChunks;
+  }
+
+  public void setOriginShiftThresholdChunks(int originShiftThresholdChunks) {
+    if (originShiftThresholdChunks < 0) {
+      throw new IllegalArgumentException("Origin shift threshold must be >= 0.");
+    }
+    this.originShiftThresholdChunks = originShiftThresholdChunks;
   }
 
   @Override

--- a/voxels-client/src/main/java/client/world/ClientWorld.java
+++ b/voxels-client/src/main/java/client/world/ClientWorld.java
@@ -10,6 +10,7 @@ public class ClientWorld extends World {
   public static final int TICKS_PER_SECOND = 20;
 
   private float fractionalTickCounter = 0;
+  private final ClientWorldOrigin origin = new ClientWorldOrigin();
 
   private ChunkManager chunkManager;
   // Warteschlange für Datenpakete vom Server
@@ -53,6 +54,10 @@ public class ClientWorld extends World {
 
   public void setChunkManager(ChunkManager chunkManager) {
     this.chunkManager = chunkManager;
+  }
+
+  public ClientWorldOrigin getOrigin() {
+    return origin;
   }
 
   public void update(float tpf) {

--- a/voxels-client/src/main/java/client/world/ClientWorldOrigin.java
+++ b/voxels-client/src/main/java/client/world/ClientWorldOrigin.java
@@ -1,0 +1,66 @@
+package client.world;
+
+import common.world.ChunkData;
+
+/**
+ * Maintains the client-side floating-origin anchor.
+ *
+ * <p>The server and world simulation continue to use absolute world/chunk coordinates. The client
+ * can rebase rendering-related systems around the current origin chunk to keep local coordinates
+ * numerically stable.
+ */
+public class ClientWorldOrigin {
+
+  private int originChunkX;
+  private int originChunkZ;
+
+  public int getOriginChunkX() {
+    return originChunkX;
+  }
+
+  public int getOriginChunkZ() {
+    return originChunkZ;
+  }
+
+  public void setOriginChunk(int chunkX, int chunkZ) {
+    this.originChunkX = chunkX;
+    this.originChunkZ = chunkZ;
+  }
+
+  public float getOriginWorldX() {
+    return originChunkX * (float) ChunkData.WIDTH;
+  }
+
+  public float getOriginWorldZ() {
+    return originChunkZ * (float) ChunkData.DEPTH;
+  }
+
+  public float toLocalX(float absoluteX) {
+    return absoluteX - getOriginWorldX();
+  }
+
+  public float toLocalY(float absoluteY) {
+    return absoluteY;
+  }
+
+  public float toLocalZ(float absoluteZ) {
+    return absoluteZ - getOriginWorldZ();
+  }
+
+  public float toAbsoluteX(float localX) {
+    return getOriginWorldX() + localX;
+  }
+
+  public float toAbsoluteY(float localY) {
+    return localY;
+  }
+
+  public float toAbsoluteZ(float localZ) {
+    return getOriginWorldZ() + localZ;
+  }
+
+  public boolean isOutsideShiftThreshold(int chunkX, int chunkZ, int thresholdInChunks) {
+    return Math.abs(chunkX - originChunkX) > thresholdInChunks
+        || Math.abs(chunkZ - originChunkZ) > thresholdInChunks;
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent floating-point precision issues in client-side rendering by rebasing local coordinates around a movable origin chunk. 
- Allow the client to keep rendering and local calculations numerically stable while the server continues to use absolute coordinates.

### Description

- Introduces a new `ClientWorldOrigin` class that stores an origin chunk, converts between absolute and local world coordinates, and exposes `isOutsideShiftThreshold` to detect when to rebase. 
- Adds a `ClientWorld.origin` instance and exposes it via `ClientWorld.getOrigin()`. 
- Integrates origin usage into `ChunkManager`: the manager now retrieves the origin from the world, checks `isOutsideShiftThreshold` each update, and calls `setOriginChunk` when the player moves past a configurable threshold; also adds `originShiftThresholdChunks` with getter/setter and a default constant. 
- Exposes the world origin from the client via `GameClient.getWorldOrigin()` to allow other systems to query local/absolute transforms.

### Testing

- Built the project to verify compilation and integration using `./gradlew build`, and the build completed successfully. 
- Ran the project's automated test task using `./gradlew test`, and the existing test suite completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c107dc8c68832da344e450233d141e)